### PR TITLE
Add Reddit OAuth2 provider with comprehensive implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ These are:
 * linkedin
 * microsoft
 * monzo
+* reddit
 * slack
 * soundcloud
 * spotify
@@ -107,6 +108,60 @@ var strURL = oLinkedIn.buildRedirectToAuthURL(
 	state = strState,
 	scope = aScope
 );
+```
+
+### Reddit
+
+#### Instantiation
+
+```
+var oReddit = new reddit(
+	client_id           = '1234567890',
+	client_secret       = 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXX',
+	redirect_uri        = 'http://redirect.fake'
+);
+```
+
+#### Authorization
+
+Reddit requires a `state` value for authorization to help protect against CSRF attacks and a `scope` array for API access permissions.
+
+Required parameters are:
+
+* `scope` - Array of permission scopes
+* `state` - Unique string to prevent CSRF attacks
+
+Optional parameters are:
+
+* `duration` - Either 'temporary' or 'permanent' (defaults to 'temporary')
+* `compact` - Boolean to use mobile-friendly authorization page (defaults to false)
+
+Available scope values include: `identity`, `edit`, `flair`, `history`, `modconfig`, `modflair`, `modlog`, `modposts`, `modwiki`, `mysubreddits`, `privatemessages`, `read`, `report`, `save`, `submit`, `subscribe`, `vote`, `wikiedit`, `wikiread`.
+
+```
+var strState = createUUID();
+var aScope = [
+	'identity',
+	'read',
+	'mysubreddits'
+];
+var strURL = oReddit.buildRedirectToAuthURL(
+	scope = aScope,
+	state = strState,
+	duration = 'permanent'
+);
+```
+
+#### Token Management
+
+Reddit supports token refresh and revocation:
+
+```
+// Refresh access token
+var refreshResponse = oReddit.refreshAccessTokenRequest( refresh_token = 'your_refresh_token' );
+
+// Revoke token
+var revokeResponse = oReddit.revokeToken( token = 'your_access_token' );
 ```
 
 ### Google

--- a/reddit.cfc
+++ b/reddit.cfc
@@ -1,0 +1,151 @@
+component extends="oauth2" accessors="true" {
+
+	property name="client_id" type="string";
+	property name="client_secret" type="string";
+	property name="authEndpoint" type="string";
+	property name="accessTokenEndpoint" type="string";
+	property name="redirect_uri" type="string";
+	
+	/**
+	* I return an initialized reddit object instance.
+	* @client_id The client ID for your application.
+	* @client_secret The client secret for your application.
+	* @authEndpoint The URL endpoint that handles the authorisation.
+	* @accessTokenEndpoint The URL endpoint that handles retrieving the access token.
+	* @redirect_uri The URL to redirect the user back to following authentication.
+	**/
+	public reddit function init(
+		required string client_id, 
+		required string client_secret, 
+		required string authEndpoint = 'https://www.reddit.com/api/v1/authorize', 
+		required string accessTokenEndpoint = 'https://www.reddit.com/api/v1/access_token',
+		required string redirect_uri
+	)
+	{
+		super.init(
+			client_id           = arguments.client_id, 
+			client_secret       = arguments.client_secret, 
+			authEndpoint        = arguments.authEndpoint, 
+			accessTokenEndpoint = arguments.accessTokenEndpoint, 
+			redirect_uri        = arguments.redirect_uri
+		);
+		return this;
+	}
+
+	/**
+	* I return the URL as a string which we use to redirect the user for authentication.
+	* @scope A required array of values to pass through for scope access. Available scopes: identity, edit, flair, history, modconfig, modflair, modlog, modposts, modwiki, mysubreddits, privatemessages, read, report, save, submit, subscribe, vote, wikiedit, wikiread.
+	* @state A unique string value of your choice that is hard to guess. Used to prevent CSRF attacks.
+	* @duration Either 'temporary' or 'permanent'. Indicates whether or not your app needs a permanent token. Choose 'temporary' for one-time requests; choose 'permanent' for ongoing tasks. Defaults to 'temporary'.
+	* @compact Boolean value. If true, uses the compact authorization page that's friendlier to small screens. Defaults to false.
+	**/
+	public string function buildRedirectToAuthURL(
+		required array scope,
+		required string state,
+		string duration = 'temporary',
+		boolean compact = false
+	){
+		var sParams = {
+			'response_type' = 'code',
+			'scope'         = arrayToList( arguments.scope, ' ' ),
+			'state'         = arguments.state,
+			'duration'      = arguments.duration
+		};
+		
+		// Use compact endpoint if requested
+		if( arguments.compact ){
+			var compactEndpoint = replace( getAuthEndpoint(), '/api/v1/authorize', '/api/v1/authorize.compact' );
+			var objAuthBuilder = new utils.authStringBuilder(
+				authEndpoint = compactEndpoint,
+				client_id = getClient_id(),
+				redirect_uri = getRedirect_uri()
+			);
+			return objAuthBuilder.withParams( sParams ).get();
+		}
+		
+		return super.buildRedirectToAuthURL( sParams );
+	}
+
+	/**
+	* I make the HTTP request to obtain the access token.
+	* @code The code returned from the authentication request.
+	**/
+	public struct function makeAccessTokenRequest(
+		required string code
+	){
+		var aFormFields = [];
+		var aHeaders = [];
+		
+		// Reddit requires HTTP Basic Auth with client_id as username and client_secret as password
+		var credentials = toBase64( getClient_id() & ':' & getClient_secret() );
+		arrayAppend( aHeaders, {
+			'name': 'Authorization',
+			'value': 'Basic ' & credentials
+		} );
+		
+		return super.makeAccessTokenRequest(
+			code       = arguments.code,
+			formfields = aFormFields,
+			headers    = aHeaders
+		);
+	}
+
+	/**
+	* I make the HTTP request to refresh the access token.
+	* @refresh_token The refresh_token returned from the accessTokenRequest request.
+	**/
+	public struct function refreshAccessTokenRequest(
+		required string refresh_token
+	){
+		var aFormFields = [];
+		var aHeaders = [];
+		
+		// Reddit requires HTTP Basic Auth for refresh token requests
+		var credentials = toBase64( getClient_id() & ':' & getClient_secret() );
+		arrayAppend( aHeaders, {
+			'name': 'Authorization',
+			'value': 'Basic ' & credentials
+		} );
+		
+		return super.refreshAccessTokenRequest(
+			refresh_token = arguments.refresh_token,
+			formfields    = aFormFields,
+			headers       = aHeaders
+		);
+	}
+
+	/**
+	* I make the HTTP request to revoke the access token.
+	* @token The access token or refresh token to revoke.
+	* @token_type_hint Optional hint about the token type ('access_token' or 'refresh_token'). Defaults to 'access_token'.
+	**/
+	public struct function revokeToken(
+		required string token,
+		string token_type_hint = 'access_token'
+	){
+		var stuResponse = {};
+		var httpService = new http();
+		httpService.setMethod( "post" ); 
+		httpService.setCharset( "utf-8" );
+		httpService.setUrl( 'https://www.reddit.com/api/v1/revoke_token' );
+		
+		// Reddit requires HTTP Basic Auth for token revocation
+		var credentials = toBase64( getClient_id() & ':' & getClient_secret() );
+		httpService.addParam( type="header", name="Authorization", value="Basic " & credentials );
+		httpService.addParam( type="header", name="Content-Type", value="application/x-www-form-urlencoded" );
+		
+		httpService.addParam( type="formfield", name="token", value=arguments.token );
+		httpService.addParam( type="formfield", name="token_type_hint", value=arguments.token_type_hint );
+		
+		var result = httpService.send().getPrefix();
+		if( '204' == result.ResponseHeader[ 'Status_Code' ] ) {
+			stuResponse.success = true;
+			stuResponse.content = 'Token revoked successfully';
+		} else {
+			stuResponse.success = false;
+			stuResponse.content = result.Statuscode;
+		}
+		return stuResponse;
+	}
+
+}

--- a/tests/specs/redditTest.cfc
+++ b/tests/specs/redditTest.cfc
@@ -1,0 +1,161 @@
+component extends='testbox.system.BaseSpec'{
+	
+	/*********************************** BDD SUITES ***********************************/
+	
+	function run(){
+
+		describe( 'Reddit Component Suite', function(){
+			
+			variables.thisProvider = 'reddit';
+			variables.sProviderData = {};
+
+			include 'providerData.properties.cfm';
+
+			if( structKeyExists( variables.providerInfo, variables.thisProvider ) ){
+				variables.sProviderData = variables.providerInfo[ variables.thisProvider ];
+			} else {
+				variables.sProviderData = variables.providerInfo[ 'default' ];
+			}
+
+			var clientId     = variables.sProviderData[ 'clientId' ];
+			var clientSecret = variables.sProviderData[ 'clientSecret' ];
+			var redirect_uri = variables.sProviderData[ 'redirect_uri' ];
+
+			var oReddit = new reddit(
+				client_id           = clientId,
+				client_secret       = clientSecret,
+				redirect_uri        = redirect_uri
+			);
+			
+			it( 'should return the correct object', function(){
+
+				expect( oReddit ).toBeInstanceOf( 'reddit' );
+				expect( oReddit ).toBeTypeOf( 'component' );
+
+			});
+
+			it( 'should have the correct properties', function() {
+
+				var sMemento = oReddit.getMemento();
+
+				expect( sMemento ).toBeStruct().toHaveLength( 5 );
+
+				expect( sMemento ).toHaveKey( 'client_id' );
+				expect( sMemento ).toHaveKey( 'client_secret' );
+				expect( sMemento ).toHaveKey( 'authEndpoint' );
+				expect( sMemento ).toHaveKey( 'accessTokenEndpoint' );
+				expect( sMemento ).toHaveKey( 'redirect_uri' );
+
+				expect( sMemento[ 'client_id' ] ).toBeString().toBe( clientId );
+				expect( sMemento[ 'client_secret' ] ).toBeString().toBe( clientSecret );
+				expect( sMemento[ 'redirect_uri' ] ).toBeString().toBe( redirect_uri );
+
+			} );
+
+			it( 'should have the correct methods', function() {
+
+				expect( oReddit ).toHaveKey( 'init' );
+				expect( oReddit ).toHaveKey( 'buildRedirectToAuthURL' );
+				expect( oReddit ).toHaveKey( 'makeAccessTokenRequest' );
+				expect( oReddit ).toHaveKey( 'refreshAccessTokenRequest' );
+				expect( oReddit ).toHaveKey( 'revokeToken' );
+				expect( oReddit ).toHaveKey( 'buildParamString' );
+				expect( oReddit ).toHaveKey( 'getMemento' );
+
+			} );
+
+			it( 'should return a string when calling the `buildRedirectToAuthURL` method', function() {
+
+				var strState = createUUID();
+				var aScope = [
+					'identity',
+					'read',
+					'mysubreddits'
+				];
+				var strURL = oReddit.buildRedirectToAuthURL(
+					scope = aScope,
+					state = strState
+				);
+
+				expect( strURL ).toBeString();
+
+				var arrData = listToArray( strURL, '&?' );
+
+				expect( arrData ).toHaveLength( 7 );
+				expect( arrData[ 1 ] )
+					.toBeString()
+					.toBe( oReddit.getAuthEndpoint() );
+
+				var stuParams = {};
+				for( var i = 2; i <= arrayLen( arrData ); i++ ){
+					structInsert( stuParams, listGetAt( arrData[ i ], 1, '=' ), listGetAt( arrData[ i ], 2, '=' ) );
+				}
+
+				expect( stuParams[ 'client_id' ] ).toBeString().toBe( clientId );
+				expect( stuParams[ 'redirect_uri' ] ).toBeString().toBe( oReddit.getRedirect_URI() );
+				expect( stuParams[ 'state' ] ).toBeString().toBe( strState );
+				expect( stuParams[ 'scope' ] ).toBeString().toBe( 'identity read mysubreddits' );
+				expect( stuParams[ 'response_type' ] ).toBeString().toBe( 'code' );
+				expect( stuParams[ 'duration' ] ).toBeString().toBe( 'temporary' );
+
+			} );
+
+			it( 'should return a string with permanent duration when specified', function() {
+
+				var strState = createUUID();
+				var aScope = [
+					'identity',
+					'read'
+				];
+				var strURL = oReddit.buildRedirectToAuthURL(
+					scope = aScope,
+					state = strState,
+					duration = 'permanent'
+				);
+
+				expect( strURL ).toBeString();
+
+				var arrData = listToArray( strURL, '&?' );
+				var stuParams = {};
+				for( var i = 2; i <= arrayLen( arrData ); i++ ){
+					structInsert( stuParams, listGetAt( arrData[ i ], 1, '=' ), listGetAt( arrData[ i ], 2, '=' ) );
+				}
+
+				expect( stuParams[ 'duration' ] ).toBeString().toBe( 'permanent' );
+
+			} );
+
+			it( 'should return a compact endpoint URL when compact is true', function() {
+
+				var strState = createUUID();
+				var aScope = [
+					'identity'
+				];
+				var strURL = oReddit.buildRedirectToAuthURL(
+					scope = aScope,
+					state = strState,
+					compact = true
+				);
+
+				expect( strURL ).toBeString();
+				expect( strURL ).toInclude( 'authorize.compact' );
+
+			} );
+
+			it( 'should have the correct default endpoints', function() {
+
+				expect( oReddit.getAuthEndpoint() )
+					.toBeString()
+					.toBe( 'https://www.reddit.com/api/v1/authorize' );
+
+				expect( oReddit.getAccessTokenEndpoint() )
+					.toBeString()
+					.toBe( 'https://www.reddit.com/api/v1/access_token' );
+
+			} );
+
+		} );
+
+	}
+	
+}


### PR DESCRIPTION
- Implemented reddit.cfc provider extending base oauth2 component
- Added support for all Reddit OAuth2 features including:
  - Standard authorization flow with state and scope parameters
  - Temporary and permanent token duration options
  - Compact authorization page support for mobile devices
  - Token refresh functionality
  - Token revocation capability
  - HTTP Basic Auth for secure API communication
- Created comprehensive test suite in redditTest.cfc
- Updated README.md with Reddit provider documentation
- Follows existing code patterns and conventions

Fixes missing Reddit OAuth2 integration for Hacktoberfest contribution